### PR TITLE
perf: Use projective coordinates to reduce the size of the reftx unlocking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ __pycache__/
 keys/
 proofs/
 wallet.json
-zkscrip_package/
+zkscript_package/
 **/prove.toml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "zkscript_package"]
 	path = zkscript_package
 	url = https://github.com/nchain-innovation/zkscript_package.git
-	branch = feat/gradient-injection-71
+	branch = perf/reduce-groth16proj-86
+	ignore = dirty

--- a/cli/bsv/wallet.py
+++ b/cli/bsv/wallet.py
@@ -498,17 +498,9 @@ class WalletManager:
             A=prepared_proof.a,
             B=prepared_proof.b,
             C=prepared_proof.c,
-            gradients_pairings=[
-                prepared_proof.gradients_b,
-                prepared_proof.gradients_minus_gamma,
-                prepared_proof.gradients_minus_delta,
-            ],
-            gradients_multiplications=prepared_proof.gradients_multiplications,
             max_multipliers=None,
-            gradients_additions=prepared_proof.gradients_additions,
             inverse_miller_output=prepared_proof.inverse_miller_loop,
-            gradient_precomputed_l_out=prepared_proof.gradient_gamma_abc_zero,
-            has_precomputed_gradients = False,
+            use_proj_coordinates = True,
         )
         
         return unlock_key.to_unlocking_script(mnt4_753)

--- a/cli/bsv/zk_utils.py
+++ b/cli/bsv/zk_utils.py
@@ -45,12 +45,8 @@ def generate_pob_utxo(
         minus_delta=prepared_vk.minus_delta,
         precomputed_l_out=vk.gamma_abc[0].to_list(),
         gamma_abc_without_l_out=[element.to_list() for element in vk.gamma_abc[1:]],
-        gradients_pairings=[
-            prepared_vk.gradients_minus_gamma,
-            prepared_vk.gradients_minus_delta,
-        ],
         sighash_flags=SIGHASH.ALL_FORKID,
-        has_precomputed_gradients=True,
+        use_proj_coordinates=True,
     )
 
     lock = RefTx(mnt4_753).locking_script(

--- a/cli/python_cli.py
+++ b/cli/python_cli.py
@@ -18,9 +18,12 @@ OUTPUT_INDEX = 0
 
 
 # Commands
+# Pegin and pegout can be replaced by pegin_with_chunks and pegout_with_chunks if 
+# transaction size exceeds 128kB
+
 ADD_BRIDGE_ENTRY_COMMAND = "cargo run -- add-bridge-entry"
-PEGIN_COMMAND = "cargo run -- pegin-with-chunks"
-PEGOUT_COMMAND = "cargo run -- pegout-with-chunks"
+PEGIN_COMMAND = "cargo run -- pegin"
+PEGOUT_COMMAND = "cargo run -- pegout"
 
 def get_bulk_tx_data(txid: str, network: WoCInterface | RPCInterface):
     if isinstance(network, WoCInterface):


### PR DESCRIPTION
Changes include:
- set `has_proj_coordinates = True` to use projective coordinates
- update the project to track the correct branch of zkscript